### PR TITLE
chore: stop querying unused graphql fields

### DIFF
--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -19,7 +19,6 @@ type Token = {
   caipAddress: string;
   name: string;
   symbol: string;
-  // info on decimals could be fetched as well, but we deliberately don't get it.
 };
 
 type CuratedInfo = {
@@ -60,12 +59,10 @@ const fetchGraphQLData = async (variables: {
       key0_contains_nocase: $targetAddress,
       status_in:[Registered, ClearingRequested]
     }, first: 1) {
-      itemID
       key0
       key1
       key2
       key3
-      key4
     }
     contractDomains: litems(where:{
       registry:"0x957a53a994860be4750810131d9c876b2f52d6e1",
@@ -73,7 +70,6 @@ const fetchGraphQLData = async (variables: {
       key1: $domain,
       status_in:[Registered, ClearingRequested]
     }, first: 1) {
-      itemID
       key0
       key1
     }
@@ -82,7 +78,6 @@ const fetchGraphQLData = async (variables: {
       key0_contains_nocase: $targetAddress,
       status_in:[Registered, ClearingRequested]
     }, first: 1) {
-      itemID
       key0
       key1
       key2


### PR DESCRIPTION
fields in domains are not used for the insights either, but they're kept because:
- you need to query something (even if you're just checking existence)
- they might be used in the future (tokens might use logo)
- can be used as reference to assert meaning of the keys

fix #36