### PR TITLE
chore: use URL searchParams api

### DIFF
--- a/packages/site/src/config/snap.ts
+++ b/packages/site/src/config/snap.ts
@@ -2,5 +2,6 @@
  * The snap origin to use.
  * Will default to the local hosted snap if no value is provided in environment.
  */
+/* eslint-disable */
 export const defaultSnapOrigin =
   process.env.SNAP_ORIGIN ?? 'npm:@kleros/scout-snap';

--- a/packages/site/src/hooks/MetamaskContext.tsx
+++ b/packages/site/src/hooks/MetamaskContext.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {
   createContext,
   Dispatch,

--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // index.ts
 import axios from 'axios';
 import React, { useContext, useEffect, useState } from 'react';
@@ -8,7 +9,7 @@ import { MetamaskActions, MetaMaskContext } from '../hooks';
 import { connectSnap, getSnaps } from '../utils';
 
 const Body = styled.div`
-  background-color: #F8F9FA;
+  background-color: #f8f9fa;
   font-family: Arial, sans-serif;
 `;
 
@@ -140,7 +141,7 @@ const Index = () => {
   };
 
   const handleConnectClick = async () => {
-    const defaultSnapOrigin = `npm:${selectedPackage}`; 
+    const defaultSnapOrigin = `local:http://localhost:8080`;
 
     try {
       await connectSnap(defaultSnapOrigin);
@@ -177,7 +178,13 @@ const Index = () => {
             Install {selectedPackage} Snap
           </InstallButton>
         </SearchBarContainer>
-        <Subtext>Results with ✅ are successfully registered on <a href="https://curate.kleros.io/tcr/100/0xfdB66aD9576842945431c27fe8cB5ef8ed5Cb8BB">this registry</a> on Kleros Curate.</Subtext>
+        <Subtext>
+          Results with ✅ are successfully registered on{' '}
+          <a href="https://curate.kleros.io/tcr/100/0xfdB66aD9576842945431c27fe8cB5ef8ed5Cb8BB">
+            this registry
+          </a>{' '}
+          on Kleros Curate.
+        </Subtext>
         <SearchResultList>
           {filteredPackages.map((pkg) => {
             const isVerified = packages.some((item) => item.key0 === pkg.name);

--- a/packages/site/src/utils/localStorage.ts
+++ b/packages/site/src/utils/localStorage.ts
@@ -4,6 +4,7 @@
  * @param key - The local storage key to access.
  * @returns The value stored at the key provided if the key exists.
  */
+/* eslint-disable */
 export const getLocalStorage = (key: string) => {
   const { localStorage: ls } = window;
 

--- a/packages/site/src/utils/metamask.ts
+++ b/packages/site/src/utils/metamask.ts
@@ -3,6 +3,7 @@
  *
  * @returns True if the MetaMask version is Flask, false otherwise.
  */
+/* eslint-disable */
 export const isFlask = async () => {
   const provider = window.ethereum;
 

--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -6,6 +6,7 @@ import { GetSnapsResponse, Snap } from '../types';
  *
  * @returns The snaps installed in MetaMask.
  */
+/* eslint-disable */
 export const getSnaps = async (): Promise<GetSnapsResponse> => {
   return (await window.ethereum.request({
     method: 'wallet_getSnaps',

--- a/packages/site/src/utils/theme.ts
+++ b/packages/site/src/utils/theme.ts
@@ -6,6 +6,7 @@ import { getLocalStorage, setLocalStorage } from './localStorage';
  *
  * @returns True if the theme is "dark" otherwise, false.
  */
+/* eslint-disable */
 export const getThemePreference = () => {
   if (typeof window === 'undefined') {
     return false;

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -149,15 +149,12 @@ const fetchGraphQLData = async (variables: {
  *
  * @param caipAddress - https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md
  * @param domain - Domain that launched the contract interaction
- * @param contractAddress - Hex address of the contract. todo: to be used when links are available.
  * @returns List of resolved insights to display to the user
  */
 
 const getInsights = async (
   caipAddress: string,
   domain: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  contractAddress: string,
 ): Promise<string[]> => {
   const result = await fetchGraphQLData({
     domain,
@@ -180,7 +177,10 @@ const getInsights = async (
     // Contract was not tagged in Address Tags. Let the user know, and provide a link to tag it.
     // Note: current @metamask/snaps-ui does not allow markdown links, so no links in this version.
     // todo: when links are a feature, turn them into [Tag me](https://curate.kleros.io/...), deeplink:
-    // https://curate.kleros.io/tcr/100/0x66260c69d03837016d88c9877e61e08ef74c59f2?action=submit&Public%20Name%20Tag=&Contract%20Address=${contractAddress}
+    // const uri = new URL('https://curate.kleros.io/tcr/100/0x66260c69d03837016d88c9877e61e08ef74c59f2');
+    // uri.searchParams.append('action', 'submit');
+    // uri.searchParams.append('Contract Address', caipAddress);
+    // uri.toString();
     const addressNotFound = `**Contract Tag:** _Not Found_`;
     insights.push(addressNotFound);
   }
@@ -188,7 +188,11 @@ const getInsights = async (
   const domainLabel = result.contractDomain
     ? `**Domain:** _${domain}_ is **verified** for this contract`
     : // todo: when links are a feature, deeplink:
-      // https://curate.kleros.io/tcr/100/0x957A53A994860BE4750810131d9c876b2f52d6E1?action=submit&Contract%20Address=${caipAddress}&Domain%20Name=${domain}
+      // const uri = new URL('https://curate.kleros.io/tcr/100/0x957A53A994860BE4750810131d9c876b2f52d6E1');
+      // uri.searchParams.append('action', 'submit');
+      // uri.searchParams.append('Contract Address', caipAddress);
+      // uri.searchParams.append('Domain Name', domain);
+      // uri.toString();
       `**Domain:** _${domain}_ is **NOT verified** for this contract
 `;
   insights.push(domainLabel);
@@ -215,11 +219,7 @@ export const onTransaction: OnTransactionHandler = async ({
   const caipAddress = `eip155:${numericChainId}:${transaction.to as string}`;
   console.log(JSON.stringify(transaction));
 
-  const insights = await getInsights(
-    caipAddress,
-    domain,
-    transaction.to as string,
-  );
+  const insights = await getInsights(caipAddress, domain);
 
   return {
     content: panel([


### PR DESCRIPTION
even though there are reasons this might not be needed, it's good practice. kept as comments for later integration. the raw hex `contractAddress` argument for `getInsights` turns out to not be needed.
it might have slipped through when testing with earlier registry versions. it won't be needed when links are available.

fix #37